### PR TITLE
fix error ZitArchive not found on epub download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
 	php7-mbstring \
 	php7-json \
 	php7-openssl \
+	php7-zip \
 	git && \
   echo "**** install app *****" && \
 	git clone https://github.com/rvolz/BicBucStriim.git /app/ && \


### PR DESCRIPTION
Hello,

I wanted to download an epud file from the bicbucstriim interface but I got an error. By inspecting the error logs I found this: 

`PHP Fatal error:  Uncaught Error: Class 'ZipArchive' not found in /config/www/vendor/`

The addition of the **php7-zip** extension fixes the problem.